### PR TITLE
Added unwrapped item back to builder closure while preserving dismissal animation.

### DIFF
--- a/Source/Modifiers.swift
+++ b/Source/Modifiers.swift
@@ -19,7 +19,7 @@ extension View {
         closeOnTap: Bool = true,
         closeOnTapOutside: Bool = false,
         backgroundColor: Color = Color.clear,
-        @ViewBuilder view: @escaping () -> PopupContent) -> some View {
+        @ViewBuilder view: @escaping (Item) -> PopupContent) -> some View {
             self.modifier(
                 Popup(
                     item: item,
@@ -74,7 +74,7 @@ extension View {
         closeOnTapOutside: Bool = false,
         backgroundColor: Color = Color.clear,
         dismissCallback: @escaping () -> (),
-        @ViewBuilder view: @escaping () -> PopupContent) -> some View {
+        @ViewBuilder view: @escaping (Item) -> PopupContent) -> some View {
             self.modifier(
                 Popup(
                     item: item,
@@ -130,7 +130,7 @@ extension View {
         closeOnTapOutside: Bool = false,
         backgroundColor: Color = Color.clear,
         dismissSourceCallback: @escaping (DismissSource) -> (),
-        @ViewBuilder view: @escaping () -> PopupContent) -> some View {
+        @ViewBuilder view: @escaping (Item) -> PopupContent) -> some View {
             self.modifier(
                 Popup(
                     item: item,


### PR DESCRIPTION
As the title says, this pull request is all about re-introducing the unwrapped item back into the builder closure. I was able to preserve the animation by caching the last non-nil Item value and falling back to it within the sheet when item is nil.