### PR TITLE
Added the item in the view closure of the popup 

### DIFF
--- a/Example/Common/ContentView.swift
+++ b/Example/Common/ContentView.swift
@@ -9,6 +9,19 @@
 import SwiftUI
 import ExytePopupView
 
+class SomeItem: Equatable {
+    
+    let value: String
+    
+    init(value: String) {
+        self.value = value
+    }
+    
+     static func == (lhs: SomeItem, rhs: SomeItem) -> Bool {
+         lhs.value == rhs.value
+     }
+}
+
 struct ToastsState {
     var showingTopFirst = false
     var showingTopSecond = false
@@ -20,7 +33,7 @@ struct PopupsState {
     var showingMiddle = false
     var showingBottomFirst = false
     var showingBottomSecond = false
-    var popupItem: String?
+    var popupItem: SomeItem?
 }
 
 struct ActionSheetsState {
@@ -122,8 +135,7 @@ struct ContentView : View {
 //        // MARK: - Designed popups
 
             .popup(isPresented: $popups.showingMiddle) {
-                PopupMiddle(isPresented: $popups.showingMiddle,
-                            item: "In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
+                PopupMiddle(isPresented: $popups.showingMiddle)
             } customize: {
                 $0
                     .closeOnTap(false)
@@ -134,7 +146,7 @@ struct ContentView : View {
                     .closeOnTap(false)
                     .backgroundColor(.black.opacity(0.4))
             }, itemView: { item in
-                PopupMiddle(isPresented: $popups.showingMiddle, item: item) {
+                ItemPopupMiddle(item: item) {
                     popups.popupItem = nil
                 }
             })

--- a/Example/Common/ContentView.swift
+++ b/Example/Common/ContentView.swift
@@ -20,11 +20,13 @@ struct PopupsState {
     var showingMiddle = false
     var showingBottomFirst = false
     var showingBottomSecond = false
+    var popupItem: String?
 }
 
 struct ActionSheetsState {
     var showingFirst = false
     var showingSecond = false
+    var text: String?
 }
 
 struct ContentView : View {
@@ -32,7 +34,7 @@ struct ContentView : View {
     @State var toasts = ToastsState()
     @State var popups = PopupsState()
     @State var actionSheets = ActionSheetsState()
-    
+    @State private var item: String?
     var body: some View {
         let commonView = createPopupsList()
         
@@ -120,13 +122,22 @@ struct ContentView : View {
 //        // MARK: - Designed popups
 
             .popup(isPresented: $popups.showingMiddle) {
-                PopupMiddle(isPresented: $popups.showingMiddle)
+                PopupMiddle(isPresented: $popups.showingMiddle,
+                            item: "In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
             } customize: {
                 $0
                     .closeOnTap(false)
                     .backgroundColor(.black.opacity(0.4))
             }
-
+            .itemPopup(item: $popups.popupItem, customize: {
+                $0
+                    .closeOnTap(false)
+                    .backgroundColor(.black.opacity(0.4))
+            }, itemView: { item in
+                PopupMiddle(isPresented: $popups.showingMiddle, item: item) {
+                    popups.popupItem = nil
+                }
+            })
             .popup(isPresented: $popups.showingBottomFirst) {
                 PopupBottomFirst(isPresented: $popups.showingBottomFirst)
             } customize: {
@@ -187,6 +198,7 @@ struct ContentView : View {
             showingMiddlePopup: $popups.showingMiddle,
             showingBottomFirstPopup: $popups.showingBottomFirst,
             showingBottomSecondPopup: $popups.showingBottomSecond,
+            showingItem: $popups.popupItem,
             showingFirstActionSheet: $actionSheets.showingFirst,
             showingSecondActionSheet: $actionSheets.showingSecond
         )

--- a/Example/Common/Views/Components/PopupButton.swift
+++ b/Example/Common/Views/Components/PopupButton.swift
@@ -24,3 +24,21 @@ struct PopupButton<Content> : View where Content : View {
         .customButtonStyle(foreground: .black, background: .clear)
     }
 }
+
+struct ItemPopupButton<Content> : View where Content : View {
+    @Binding var text: String?
+    
+    var hideAll: () -> ()
+    
+    @ViewBuilder let content: () -> Content
+    
+    var body: some View {
+        Button {
+            text = "This is the unwrapped item"
+            hideAll()
+        } label: {
+            content()
+        }
+        .customButtonStyle(foreground: .black, background: .clear)
+    }
+}

--- a/Example/Common/Views/Components/PopupButton.swift
+++ b/Example/Common/Views/Components/PopupButton.swift
@@ -26,7 +26,7 @@ struct PopupButton<Content> : View where Content : View {
 }
 
 struct ItemPopupButton<Content> : View where Content : View {
-    @Binding var text: String?
+    @Binding var item: SomeItem?
     
     var hideAll: () -> ()
     
@@ -34,7 +34,7 @@ struct ItemPopupButton<Content> : View where Content : View {
     
     var body: some View {
         Button {
-            text = "This is the unwrapped item"
+            item = SomeItem(value: "This is the unwrapped item")
             hideAll()
         } label: {
             content()

--- a/Example/Common/Views/Examples/Popups.swift
+++ b/Example/Common/Views/Examples/Popups.swift
@@ -8,9 +8,48 @@
 import SwiftUI
 
 struct PopupMiddle: View {
-
     @Binding var isPresented: Bool
-    let item: String
+    var body: some View {
+        VStack(spacing: 12) {
+            Image("winner")
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: 226, maxHeight: 226)
+            
+            Text("Congratulations!")
+                .foregroundColor(.black)
+                .font(.system(size: 24))
+                .padding(.top, 12)
+            
+            Text("In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
+                .foregroundColor(.black)
+                .font(.system(size: 16))
+                .opacity(0.6)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 20)
+            
+            Button("Thanks") {
+                isPresented = false
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 18, weight: .bold))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 18)
+            .padding(.horizontal, 24)
+            .foregroundColor(.white)
+            .background(Color(hex: "9265F8"))
+            .cornerRadius(12)
+        }
+        .padding(EdgeInsets(top: 37, leading: 24, bottom: 40, trailing: 24))
+        .background(Color.white.cornerRadius(20))
+        .shadowedStyle()
+        .padding(.horizontal, 40)
+    }
+}
+
+struct ItemPopupMiddle: View {
+
+    let item: SomeItem
     var closure: () -> Void = { }
     var body: some View {
         VStack(spacing: 12) {
@@ -24,7 +63,7 @@ struct PopupMiddle: View {
                 .font(.system(size: 24))
                 .padding(.top, 12)
             
-            Text(item)
+            Text(item.value)
                 .foregroundColor(.black)
                 .font(.system(size: 16))
                 .opacity(0.6)
@@ -32,7 +71,6 @@ struct PopupMiddle: View {
                 .padding(.bottom, 20)
             
             Button("Thanks") {
-                isPresented = false
                 closure()
             }
             .buttonStyle(.plain)
@@ -132,8 +170,7 @@ struct Popups_Previews: PreviewProvider {
         ZStack {
             Rectangle()
                 .ignoresSafeArea()
-            PopupMiddle(isPresented: .constant(true),
-                        item: "In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
+            PopupMiddle(isPresented: .constant(true))
         }
         
         ZStack {

--- a/Example/Common/Views/Examples/Popups.swift
+++ b/Example/Common/Views/Examples/Popups.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct PopupMiddle: View {
 
     @Binding var isPresented: Bool
-
+    let item: String
+    var closure: () -> Void = { }
     var body: some View {
         VStack(spacing: 12) {
             Image("winner")
@@ -23,7 +24,7 @@ struct PopupMiddle: View {
                 .font(.system(size: 24))
                 .padding(.top, 12)
             
-            Text("In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
+            Text(item)
                 .foregroundColor(.black)
                 .font(.system(size: 16))
                 .opacity(0.6)
@@ -32,6 +33,7 @@ struct PopupMiddle: View {
             
             Button("Thanks") {
                 isPresented = false
+                closure()
             }
             .buttonStyle(.plain)
             .font(.system(size: 18, weight: .bold))
@@ -130,7 +132,8 @@ struct Popups_Previews: PreviewProvider {
         ZStack {
             Rectangle()
                 .ignoresSafeArea()
-            PopupMiddle(isPresented: .constant(true))
+            PopupMiddle(isPresented: .constant(true),
+                        item: "In two weeks, you did 12 workouts and burned 2671 calories. That's 566 calories more than last month. Continue at the same pace and the result will please you.")
         }
         
         ZStack {

--- a/Example/Common/Views/PopupsList.swift
+++ b/Example/Common/Views/PopupsList.swift
@@ -77,7 +77,7 @@ struct PopupsList: View {
     @Binding var showingMiddlePopup: Bool
     @Binding var showingBottomFirstPopup: Bool
     @Binding var showingBottomSecondPopup: Bool
-    
+    @Binding var showingItem: String?
 #if os(iOS)
     @Binding var showingFirstActionSheet: Bool
     @Binding var showingSecondActionSheet: Bool
@@ -198,6 +198,14 @@ struct PopupsList: View {
                         PopupButton(isShowing: $showingMiddlePopup, hideAll: hideAll) {
                             PopupTypeView(
                                 title: "Middle",
+                                detail: "Popup in the middle of the screen with a picture"
+                            ) {
+                                PopupImage(style: .default)
+                            }
+                        }
+                        ItemPopupButton(text: $showingItem, hideAll: hideAll) {
+                            PopupTypeView(
+                                title: "Middle with Binding",
                                 detail: "Popup in the middle of the screen with a picture"
                             ) {
                                 PopupImage(style: .default)

--- a/Example/Common/Views/PopupsList.swift
+++ b/Example/Common/Views/PopupsList.swift
@@ -77,7 +77,7 @@ struct PopupsList: View {
     @Binding var showingMiddlePopup: Bool
     @Binding var showingBottomFirstPopup: Bool
     @Binding var showingBottomSecondPopup: Bool
-    @Binding var showingItem: String?
+    @Binding var showingItem: SomeItem?
 #if os(iOS)
     @Binding var showingFirstActionSheet: Bool
     @Binding var showingSecondActionSheet: Bool
@@ -203,7 +203,7 @@ struct PopupsList: View {
                                 PopupImage(style: .default)
                             }
                         }
-                        ItemPopupButton(text: $showingItem, hideAll: hideAll) {
+                        ItemPopupButton(item: $showingItem, hideAll: hideAll) {
                             PopupTypeView(
                                 title: "Middle with Binding",
                                 detail: "Popup in the middle of the screen with a picture"

--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -57,8 +57,8 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
     /// opacity of background color
     @State private var opacity = 0.0
     
-    /// A temporary view to hold a copy of the `itemView` when the item is nil (to complete `itemView`'s dismiss animation)
-    @State private var tempView: (() -> PopupContent)!
+    /// A temporary variable to hold a copy of the `item` when the item is nil (to complete `itemView`'s dismiss animation)
+    @State private var tempItem: Item?
 
     // MARK: - Autohide
 
@@ -131,8 +131,8 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
             main(content: content)
                 .onChange(of: item) { newValue in
                     if let newValue {
-                        /// copying `itemView`
-                        self.tempView = { itemView(newValue) }
+                        /// copying `item`
+                        self.tempItem = newValue
                     }
                     appearAction(sheetPresented: newValue != nil)
                 }
@@ -177,26 +177,26 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
         }
     }
     
-    private func getItemView() -> (() -> PopupContent)? {
-        if let item {
+    var viewForItem: (() -> PopupContent)? {
+        if let item = item ?? tempItem {
             return { itemView(item) }
         }
-        return tempView
+        return nil
     }
     
     private func getModifier() -> Popup<Item, PopupContent> {
-        if let viewOfItem = getItemView() {
+        if let viewForItem {
             return Popup(
                 isPresented: $isPresented,
                 item: $item,
                 params: params,
-                view: viewOfItem,
+                view: viewForItem,
                 shouldShowContent: shouldShowContent,
                 showContent: showContent,
                 dismissSource: $dismissSource,
                 animationCompletedCallback: onAnimationCompleted
             )
-        } else  {
+        } else {
             return Popup(
                 isPresented: $isPresented,
                 params: params,

--- a/Source/Modifiers.swift
+++ b/Source/Modifiers.swift
@@ -35,4 +35,17 @@ extension View {
                     view: view)
             )
         }
+    
+    public func itemPopup<Item: Equatable, PopupContent: View>(
+        item: Binding<Item?>,
+        customize: @escaping (Popup<Item, PopupContent>.PopupParameters) -> Popup<Item, PopupContent>.PopupParameters,
+        @ViewBuilder itemView: @escaping (Item) -> PopupContent) -> some View {
+            self.modifier(
+                FullscreenPopup<Item, PopupContent>(
+                    item: item,
+                    isBoolMode: false,
+                    params: customize(Popup<Item, PopupContent>.PopupParameters()),
+                    itemView: itemView)
+            )
+        }
 }


### PR DESCRIPTION
(apologies, the previous PR was done from the wrong account!)

in SwiftUI, you have something like that: 
```swift
 .fullScreenCover(item: $seletedItem) { item in
       // some view with the item
  }
```

That rather simple and straight forward functionality is what is missing from this wonderful library,
of course you can mimic that behavior by optionally unwrapping the item with the current state of things, but it seems kinda "non-swify" for my taste.
so I tried to implement it here  in the following fashion :
```swift
            .itemPopup(item: $popups.popupItem, customize: {
                $0
                    .closeOnTap(false)
                    .backgroundColor(.black.opacity(0.4))
            }, itemView: { item in
                ItemPopupMiddle(item: item) {
                    popups.popupItem = nil
                }
            })
```
This is my implementation of making it work just like in the example above.

Happy to get some feedback!
