### PR TITLE
Add deinit code for fix memory leak

### DIFF
--- a/PopupView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PopupView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -254,6 +254,7 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                 isPresentedRef?.value.wrappedValue = false
                 itemRef?.value.wrappedValue = nil
                 dismissSource = .autohide
+                dispatchWorkHolder.work = nil
             })
             if sheetPresented, let work = dispatchWorkHolder.work {
                 DispatchQueue.main.asyncAfter(deadline: .now() + autohideIn, execute: work)


### PR DESCRIPTION
Hello,

I encountered an issue with the memory leak in your library.

I noticed a memory leak when using the @StateObject property wrapper in your library. Specifically, when I create an instance of a class that conforms to ObservableObject using @StateObject in a view, the object remains in memory even after the view is dismissed.

<img width="129" alt="memory_leak_2" src="https://user-images.githubusercontent.com/77499260/232794010-8ecaa562-c899-467a-904d-eaa6d87c8fa8.png"> <img width="252" alt="memory _leak_1" src="https://user-images.githubusercontent.com/77499260/232794031-4c88e4d7-0922-460f-a5d6-b1c985069999.png"> <img width="300" alt="memory_leak_3" src="https://user-images.githubusercontent.com/77499260/232794043-47b38e73-ae72-4b9e-8b69-1d4b4534d0da.png">

I've confirmed that this issue doesn't occur when using the @State property wrapper instead, and I've also verified that there are no retain cycles in my code that could be causing the leak.

After investigating, I believe I have identified the source of the problem and have implemented a fix in my fork. I would like to submit a pull request to merge my changes into the main branch.

Thank you for maintaining this library and providing such a valuable resource. I appreciate the opportunity to contribute to the project and help improve it. Please let me know if there are any issues or concerns with my proposed changes, or if there's anything else I can do to help with the review process.

Thanks again for your time and consideration.