### PR TITLE
fix: Popup is not presented when the initial presented biding is true

### DIFF
--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -128,6 +128,11 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                 .onChange(of: isPresented) { newValue in
                     appearAction(sheetPresented: newValue)
                 }
+                .onAppear {
+                    if isPresented {
+                        appearAction(sheetPresented: true)
+                    }
+                }
         } else {
             main(content: content)
                 .onChange(of: item) { newValue in
@@ -136,6 +141,10 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                         self.tempItem = newValue
                     }
                     appearAction(sheetPresented: newValue != nil)
+                }.onAppear {
+                    if item != nil {
+                        appearAction(sheetPresented: true)
+                    }
                 }
         }
     }


### PR DESCRIPTION
- when the isPresented biding initial values is true or the presented item is initially not nil the popup would not be presented

This addresses #105 let me know whether this is ok or bad 😄 I'll be happy to modify this as you require.