### PR TITLE
Fix keyboard animation

### DIFF
--- a/Source/Utils.swift
+++ b/Source/Utils.swift
@@ -297,7 +297,7 @@ class KeyboardHeightHelper: ObservableObject {
     }
 
     private func listenForKeyboardNotifications() {
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification,
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification,
                                                object: nil,
                                                queue: .main) { (notification) in
             guard let userInfo = notification.userInfo,
@@ -307,7 +307,7 @@ class KeyboardHeightHelper: ObservableObject {
             self.keyboardDisplayed = true
         }
 
-        NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification,
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification,
                                                object: nil,
                                                queue: .main) { (notification) in
             self.keyboardHeight = 0


### PR DESCRIPTION
Hi, I had a problem with the keyboard animation.
This is very noticeable when use - `.closeOnTapOutside(true)`.

Current master:
<img width="200" src="https://user-images.githubusercontent.com/13507976/235871568-e4206381-7c6d-4ccb-8bfd-3eb21714041d.gif" />

My solution:
<img width="200" src="https://user-images.githubusercontent.com/13507976/235871587-894c9f28-68dc-4303-88f8-2fdbba94fd0c.gif" />
