### PR TITLE
fix: Popup is not presented when Menu is presenting

### DIFF
--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -114,7 +114,10 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
         if isBoolMode {
             main(content: content)
                 .onChange(of: isPresented) { newValue in
-                    appearAction(sheetPresented: newValue)
+                    // minimum time to represent
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
+                        appearAction(sheetPresented: newValue)
+                    }
                 }
                 .onAppear {
                     if isPresented {
@@ -124,11 +127,13 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
         } else {
             main(content: content)
                 .onChange(of: item) { newValue in
-                    if let newValue {
-                        /// copying `item`
-                        self.tempItem = newValue
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
+                        if let newValue {
+                            /// copying `item`
+                            self.tempItem = newValue
+                        }
+                        appearAction(sheetPresented: newValue != nil)
                     }
-                    appearAction(sheetPresented: newValue != nil)
                 }
                 .onAppear {
                     if item != nil {


### PR DESCRIPTION
fix Attempt to present PresentationHostingController which is already presenting with minimum delay.

`[Presentation] Attempt to present <SwiftUI29PresentationHostingControllerVS_7AnyView_: on <_TtGC7SwiftUI19UIHostingControllerGVS_15ModifiedContentVS_7AnyViewVS_12RootModifier__: (from <_TtGC7SwiftUI19UIHostingControllerVVS_P10$19cb8fa2821BridgedNavigationView8RootView_:) which is already presenting <_UIContextMenuActionsOnlyViewController
`
Description : 
when a Menu() is presenting and user click on a button in the main UI that opens a PopupView, the PopupView not presenting at the time.