### PR TITLE
improve default position in macCatalyst

### DIFF
--- a/Source/PopupView.swift
+++ b/Source/PopupView.swift
@@ -50,7 +50,16 @@ public struct Popup<PopupContent: View>: ViewModifier {
 
         var defaultPosition: Position {
             if case .default = self {
+#if os(iOS)
+    #if targetEnvironment(macCatalyst)
+                return .leading
+    #else
                 return .center
+    #endif
+
+#else
+                return .center
+#endif
             }
             return .bottom
         }


### PR DESCRIPTION
when create popup in macCatalyst the popup not fully shown in window. it will fix by setting default position to leading.
```
       .popup(isPresented: $popupError) {
                                PopupError() 
                                    
                            } customize: {
                                $0
                                    .closeOnTapOutside(true)
                                    .closeOnTap(false)
                                    .backgroundColor(.black.opacity(0.4))
                            }
```
i don't check it in macOS, maybe also it happens there.