### PR TITLE
Possible fix for Status Bar Color changing color to black when presenting a view with .fullScreenCover

### DIFF
--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -37,6 +37,9 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
 
     /// If opaque taps do not pass through popup's background color. Always opaque if closeOnTapOutside is true
     var isOpaque: Bool
+    
+    /// Used when `isQpaque == true`. Sets the color of the status bar.
+    var statusBarColor: StatusBarColor
 
     /// Is called on any close action
     var userDismissCallback: (DismissSource) -> ()
@@ -97,6 +100,7 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
         self.backgroundColor = params.backgroundColor
         self.backgroundView = params.backgroundView
         self.isOpaque = params.isOpaque
+        self.statusBarColor = params.statusBarColor
         self.userDismissCallback = params.dismissCallback
 
         if let view = view {
@@ -148,7 +152,7 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
     public func main(content: Content) -> some View {
         if opaqueBackground {
 #if os(iOS)
-            content.transparentNonAnimatingFullScreenCover(isPresented: $showSheet) {
+            content.transparentNonAnimatingFullScreenCover(isPresented: $showSheet, colorScheme: statusBarColor.colorScheme) {
                 constructPopup()
             }
 #else
@@ -276,4 +280,13 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
         }
     }
 
+}
+
+extension StatusBarColor {
+    fileprivate var colorScheme: ColorScheme {
+        switch self {
+        case .light: return .dark
+        case .dark: return .light
+        }
+    }
 }

--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -177,7 +177,6 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                 backgroundColor
             }
         }
-        .preferredColorScheme(statusBarColor.colorScheme)
         .opacity(opacity)
         .applyIf(closeOnTapOutside) { view in
             view.contentShape(Rectangle())

--- a/Source/FullscreenPopup.swift
+++ b/Source/FullscreenPopup.swift
@@ -177,6 +177,7 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                 backgroundColor
             }
         }
+        .preferredColorScheme(statusBarColor.colorScheme)
         .opacity(opacity)
         .applyIf(closeOnTapOutside) { view in
             view.contentShape(Rectangle())

--- a/Source/PopupView.swift
+++ b/Source/PopupView.swift
@@ -16,6 +16,11 @@ public enum DismissSource {
     case autohide
 }
 
+public enum StatusBarColor {
+    case light
+    case dark
+}
+
 public struct Popup<PopupContent: View>: ViewModifier {
 
     init(params: Popup<PopupContent>.PopupParameters,
@@ -151,6 +156,9 @@ public struct Popup<PopupContent: View>: ViewModifier {
 
         /// If true taps do not pass through popup's background and the popup is displayed on top of navbar. Always opaque if closeOnTapOutside is true
         var isOpaque: Bool = false
+        
+        /// Used when `isQpaque == true`. Sets the color of the status bar.
+        var statusBarColor: StatusBarColor = .dark
 
         var dismissCallback: (DismissSource) -> () = {_ in}
 
@@ -217,6 +225,12 @@ public struct Popup<PopupContent: View>: ViewModifier {
         public func isOpaque(_ isOpaque: Bool) -> PopupParameters {
             var params = self
             params.isOpaque = isOpaque
+            return params
+        }
+        
+        public func statusBarColor(_ statusBarColor: StatusBarColor) -> PopupParameters {
+            var params = self
+            params.statusBarColor = statusBarColor
             return params
         }
 

--- a/Source/Utils.swift
+++ b/Source/Utils.swift
@@ -240,7 +240,7 @@ private struct TransparentNonAnimatableFullScreenModifier<FullScreenContent: Vie
                     fullScreenContent()
                 }
                 .background(FullScreenCoverBackgroundRemovalView())
-                .preferredColorScheme(colorScheme)
+                //.preferredColorScheme(colorScheme)
                 .onAppear {
                     if !UIView.areAnimationsEnabled {
                         UIView.setAnimationsEnabled(true)

--- a/Source/Utils.swift
+++ b/Source/Utils.swift
@@ -240,7 +240,7 @@ private struct TransparentNonAnimatableFullScreenModifier<FullScreenContent: Vie
                     fullScreenContent()
                 }
                 .background(FullScreenCoverBackgroundRemovalView())
-                //.preferredColorScheme(colorScheme)
+                .preferredColorScheme(colorScheme)
                 .onAppear {
                     if !UIView.areAnimationsEnabled {
                         UIView.setAnimationsEnabled(true)

--- a/Source/Utils.swift
+++ b/Source/Utils.swift
@@ -215,14 +215,19 @@ extension View {
 
 extension View {
 
-    func transparentNonAnimatingFullScreenCover<Content: View>(isPresented: Binding<Bool>, content: @escaping () -> Content) -> some View {
-        modifier(TransparentNonAnimatableFullScreenModifier(isPresented: isPresented, fullScreenContent: content))
+    func transparentNonAnimatingFullScreenCover<Content: View>(isPresented: Binding<Bool>,
+                                                               colorScheme: ColorScheme,
+                                                               content: @escaping () -> Content) -> some View {
+        modifier(TransparentNonAnimatableFullScreenModifier(isPresented: isPresented,
+                                                            colorScheme: colorScheme,
+                                                            fullScreenContent: content))
     }
 }
 
 private struct TransparentNonAnimatableFullScreenModifier<FullScreenContent: View>: ViewModifier {
 
     @Binding var isPresented: Bool
+    let colorScheme: ColorScheme
     let fullScreenContent: () -> (FullScreenContent)
 
     func body(content: Content) -> some View {
@@ -235,6 +240,7 @@ private struct TransparentNonAnimatableFullScreenModifier<FullScreenContent: Vie
                     fullScreenContent()
                 }
                 .background(FullScreenCoverBackgroundRemovalView())
+                .preferredColorScheme(colorScheme)
                 .onAppear {
                     if !UIView.areAnimationsEnabled {
                         UIView.setAnimationsEnabled(true)


### PR DESCRIPTION
Noticed a possible SwiftUI bug when presenting any View with `.fullScreenCover`. The status bar color changes to black regardless of the global setting for that color. The only fix I've found was to force the color with `.preferredColorScheme`.