### PR TITLE
Add Environment-based Dismiss Functionality to Popup and Fix Swift Build ErrorFeature/add environment dismiss

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftui-introspect",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/siteline/swiftui-introspect",
+      "state" : {
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/PopupExample/PopupExample/Views/Examples/FloatsSmall.swift
+++ b/PopupExample/PopupExample/Views/Examples/FloatsSmall.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct FloatTopFirst: View {
 
     @Binding var isShowing: Bool
+    @Environment(\.popupDismiss) var dismiss
 
     var body: some View {
         ZStack {
@@ -33,7 +34,8 @@ struct FloatTopFirst: View {
                     
                     Button {
                         debugPrint("Accepted!")
-                        isShowing = false
+//                        isShowing = false
+                        dismiss?()
                     } label: {
                         Text("Accept".uppercased())
                             .font(.system(size: 14, weight: .black))

--- a/PopupExample/PopupExample/Views/Examples/Popups.swift
+++ b/PopupExample/PopupExample/Views/Examples/Popups.swift
@@ -11,6 +11,7 @@ struct PopupMiddle: View {
 
     let item: SomeItem
     var onClose: () -> Void
+    @Environment(\.popupDismiss) var dismiss
 
     var body: some View {
         VStack(spacing: 12) {
@@ -32,7 +33,8 @@ struct PopupMiddle: View {
                 .padding(.bottom, 20)
             
             Button {
-                onClose()
+//                onClose()
+                dismiss?()
             } label: {
                 Text("Thanks")
                     .font(.system(size: 18, weight: .bold))

--- a/Sources/PopupView/Modifiers.swift
+++ b/Sources/PopupView/Modifiers.swift
@@ -77,13 +77,17 @@ struct OrientationChangeModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onAppear {
+#if os(iOS)
                 NotificationCenter.default.addObserver(forName: UIDevice.orientationDidChangeNotification, object: nil, queue: .main) { _ in
                     updateOrientation()
                 }
                 updateOrientation()
+#endif
             }
             .onDisappear {
+                #if os(iOS)
                 NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+                #endif
             }
             .onChange(of: isLandscape) { _ in
                 onOrientationChange()
@@ -91,6 +95,7 @@ struct OrientationChangeModifier: ViewModifier {
     }
     
     private func updateOrientation() {
+        #if os(iOS)
         DispatchQueue.main.async {
             let newIsLandscape = UIDevice.current.orientation.isLandscape
             if newIsLandscape != isLandscape {
@@ -98,6 +103,7 @@ struct OrientationChangeModifier: ViewModifier {
                 onOrientationChange()
             }
         }
+        #endif
     }
 }
 

--- a/Sources/PopupView/Modifiers.swift
+++ b/Sources/PopupView/Modifiers.swift
@@ -7,6 +7,17 @@
 
 import SwiftUI
 
+struct PopupDismissKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+public extension EnvironmentValues {
+    var popupDismiss: (() -> Void)? {
+        get { self[PopupDismissKey.self] }
+        set { self[PopupDismissKey.self] = newValue }
+    }
+}
+
 extension View {
 
     public func popup<PopupContent: View>(
@@ -22,6 +33,9 @@ extension View {
                     view: view,
                     itemView: nil)
             )
+            .environment(\.popupDismiss, {
+                isPresented.wrappedValue = false
+            })
         }
 
     public func popup<Item: Equatable, PopupContent: View>(
@@ -37,6 +51,9 @@ extension View {
                     view: nil,
                     itemView: itemView)
             )
+            .environment(\.popupDismiss, {
+                item.wrappedValue = nil
+            })
         }
 
     public func popup<PopupContent: View>(
@@ -50,6 +67,9 @@ extension View {
                     view: view,
                     itemView: nil)
             )
+            .environment(\.popupDismiss, {
+                isPresented.wrappedValue = false
+            })
         }
 
     public func popup<Item: Equatable, PopupContent: View>(
@@ -63,6 +83,9 @@ extension View {
                     view: nil,
                     itemView: itemView)
             )
+            .environment(\.popupDismiss, {
+                item.wrappedValue = nil
+            })
         }
     
     func onOrientationChange(isLandscape: Binding<Bool>, onOrientationChange: @escaping () -> Void) -> some View {

--- a/Sources/PopupView/PopupView.swift
+++ b/Sources/PopupView/PopupView.swift
@@ -390,7 +390,9 @@ public struct Popup<PopupContent: View>: ViewModifier {
     /// Variables used to control what is animated and what is not
     @State var actualCurrentOffset = CGPoint.pointFarAwayFromScreen
     @State var actualScale = 1.0
+    #if os(iOS)
     @State private var isLandscape: Bool = UIDevice.current.orientation.isLandscape
+    #endif
     // MARK: - Drag to dismiss
 
     /// Drag to dismiss gesture state
@@ -707,9 +709,11 @@ public struct Popup<PopupContent: View>: ViewModifier {
                 .onChange(of: sheetContentRect.size) { sheetContentRect in
                     positionIsCalculatedCallback()
                 }
+#if os(iOS)
                 .onOrientationChange(isLandscape: $isLandscape) {
                     actualCurrentOffset = targetCurrentOffset
                 }
+#endif
             }
         } else { // ios 16
             ZStack {
@@ -750,9 +754,11 @@ public struct Popup<PopupContent: View>: ViewModifier {
                 .onChange(of: sheetContentRect.size) { sheetContentRect in
                     positionIsCalculatedCallback()
                 }
+#if os(iOS)
                 .onOrientationChange(isLandscape: $isLandscape) {
                     actualCurrentOffset = targetCurrentOffset
                 }
+#endif
             }
         }
     }


### PR DESCRIPTION
This PR introduces an @Environment based dismiss functionality for the popup modifier, allowing for a more intuitive and SwiftUI-consistent way to dismiss popups. The dismiss function is now accessible via @Environment(\.popupDismiss) in popup content views.

Additionally, this PR addresses an issue where running `swift build` command would result in an error. The necessary adjustments have been made to ensure compatibility and successful builds.