### PR TITLE
fixed scroll bug for ios 18

### DIFF
--- a/Sources/PopupView/PopupView.swift
+++ b/Sources/PopupView/PopupView.swift
@@ -779,8 +779,9 @@ public struct Popup<PopupContent: View>: ViewModifier {
 
         return sheet()
             .applyIf(dragToDismiss) {
-                $0.offset(dragOffset())
-                    .simultaneousGesture(drag)
+                $0
+                    .offset(dragOffset())
+                    .gesture(drag)
             }
 #else
         return sheet()


### PR DESCRIPTION
After the analysis, I found the cause of bug #216, simultaneous Gesture led to the fact that global gesture and scrollview were processed simultaneously.

I tested the app on iOS 16,17,18.
everything works fine.