### PR TITLE
Smooth Dragging with minimumDistance in DragGesture

### DIFF
--- a/Sources/PopupView/PopupView.swift
+++ b/Sources/PopupView/PopupView.swift
@@ -771,7 +771,7 @@ public struct Popup<PopupContent: View>: ViewModifier {
 
     func sheetWithDragGesture() -> some View {
 #if !os(tvOS)
-        let drag = DragGesture()
+        let drag = DragGesture(minimumDistance: 0)
             .updating($dragState) { drag, state, _ in
                 state = .dragging(translation: drag.translation)
             }


### PR DESCRIPTION
The minimumDistance for DragGesture is set to make dragging smoother. By default, the value is 10, which can cause jittering when dragging slowly.