### PR TITLE
 [Fix] Fix hit-testing passthrough on iOS 26

### DIFF
--- a/Sources/PopupView/WindowManager.swift
+++ b/Sources/PopupView/WindowManager.swift
@@ -54,7 +54,14 @@ class UIPassthroughWindow: UIWindow {
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if let vc = self.rootViewController {
             vc.view.layoutSubviews() // otherwise the frame is as if the popup is still outside the screen
-            if let _ = isTouchInsideSubview(point: point, view: vc.view) {
+            
+            let pointInRoot = vc.view.convert(point, from: self)
+            
+            // iOS26 Passthrough Find Issue
+            if #available(iOS 26, *), vc.view.point(inside: pointInRoot, with: event) {
+                return vc.view
+            }
+            if let _ = isTouchInsideSubview(point: pointInRoot, view: vc.view) {
                 // pass tap to this UIPassthroughVC
                 return vc.view
             }


### PR DESCRIPTION
## Summary
This PR addresses a touch passthrough issue that occurs on iOS 26 when a popup transitions from off-screen to on-screen. With a minimal and localized change inside hitTest(_:with:), touches are now correctly delivered to the popup without affecting other behavior.

## Changes
Changes
• Convert the touch point into the root view’s coordinate space for accurate hit-testing.
• On iOS 26+, use point(inside:with:) to correctly detect touches and return vc.view when appropriate.
• Fallback to existing isTouchInsideSubview logic to preserve previous behavior on older iOS versions.