### PR TITLE
Fix issue 254 - BackGround Touch Not Work Issue Fix

### DIFF
--- a/Sources/PopupView/WindowManager.swift
+++ b/Sources/PopupView/WindowManager.swift
@@ -59,7 +59,7 @@ class UIPassthroughWindow: UIWindow {
             
             // iOS26 Passthrough Find Issue
             if #available(iOS 26, *), vc.view.point(inside: pointInRoot, with: event) {
-                return vc.view
+                return isTouchInsideSubviewForiOS26(point: pointInRoot, view: vc.view)
             }
             if let _ = isTouchInsideSubview(point: pointInRoot, view: vc.view) {
                 // pass tap to this UIPassthroughVC
@@ -76,6 +76,14 @@ class UIPassthroughWindow: UIWindow {
             }
         }
         return nil
+    }
+    
+    @available(iOS 26.0, *)
+    private func isTouchInsideSubviewForiOS26(point: CGPoint, view: UIView) -> UIView? {
+        guard view.layer.hitTest(point)?.name == nil else {
+            return nil
+        }
+        return view
     }
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a touch passthrough issue on iOS 26 when a popup transitions from off-screen to on-screen. With a minimal, localized change inside hitTest(_:with:), touches are now correctly delivered to the popup without altering existing behavior.

## Changes
• Convert the touch point into the root view’s coordinate space for accurate hit-testing.
• On iOS 26+, use point(inside:with:) together with isTouchInsideSubviewForiOS26 to ensure only intended touch regions receive input:

```swift
@available(iOS 26.0, *)
  private func isTouchInsideSubviewForiOS26(point: CGPoint, view: UIView) -> UIView? {
      guard view.layer.hitTest(point)?.name == nil else {
          return nil
      }
      return view
  }
```

• Fallback to the existing isTouchInsideSubview logic on older iOS versions to preserve previous behavior.

Result
• Only the areas that should be touchable are now touchable; background taps pass through as expected.


I am sorry for raising the PR again.