### PR TITLE
Fix popup window not closing when parent view is removed (#264, #267, #251)

### DIFF
--- a/Sources/PopupView/FullscreenPopup.swift
+++ b/Sources/PopupView/FullscreenPopup.swift
@@ -219,6 +219,9 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
                         WindowManager.closeWindow(id: id)
                     }
                 }
+                .onDisappear {
+                    WindowManager.closeWindow(id: id)
+                }
         }
 #else
             ZStack {


### PR DESCRIPTION
Adds  `.onDisappear {  WindowManager.closeWindow(id: id) }`
Fixes #264, #267, #251