### PR TITLE
Improve UIPassthroughWindow hitTest

### DIFF
--- a/Sources/PopupView/FullscreenPopup.swift
+++ b/Sources/PopupView/FullscreenPopup.swift
@@ -208,13 +208,17 @@ public struct FullscreenPopup<Item: Equatable, PopupContent: View>: ViewModifier
             content
                 .onChange(of: showSheet) { newValue in
                     if newValue {
-                        WindowManager.showInNewWindow(id: id, allowTapThroughBG: allowTapThroughBG, dismissClosure: {
-                            dismissSource = .binding
-                            isPresented = false
-                            item = nil
-                        }) {
-                            constructPopup()
-                        }
+                        WindowManager.showInNewWindow(
+                            id: id,
+                            closeOnTapOutside: closeOnTapOutside,
+                            allowTapThroughBG: allowTapThroughBG,
+                            dismissClosure: {
+                                dismissSource = .tapOutside
+                                isPresented = false
+                                item = nil
+                            }) {
+                                constructPopup()
+                            }
                     } else {
                         WindowManager.closeWindow(id: id)
                     }

--- a/Sources/PopupView/PopupBackgroundView.swift
+++ b/Sources/PopupView/PopupBackgroundView.swift
@@ -25,26 +25,33 @@ struct PopupBackgroundView<Item: Equatable>: View {
     var dismissEnabled: Binding<Bool>
 
     var body: some View {
-        Group {
-            if let backgroundView = backgroundView {
-                backgroundView
-            } else {
-                backgroundColor
+        ZStack {
+            Group {
+                if let backgroundView = backgroundView {
+                    backgroundView
+                } else {
+                    backgroundColor
+                }
             }
+            .allowsHitTesting(!allowTapThroughBG)
+            .opacity(animatableOpacity)
+            .edgesIgnoringSafeArea(.all)
+            .animation(.linear(duration: 0.2), value: animatableOpacity)
+            
+            PopupHitTestingBackground() // Hit testing workaround
+                .ignoresSafeArea()
         }
-        .allowsHitTesting(!allowTapThroughBG)
-        .opacity(animatableOpacity)
-        .applyIf(closeOnTapOutside) { view in
-            view.contentShape(Rectangle())
-        }
-        .addTapIfNotTV(if: closeOnTapOutside) {
-            if dismissEnabled.wrappedValue {
-                dismissSource = .tapOutside
-                isPresented = false
-                item = nil
-            }
-        }
-        .edgesIgnoringSafeArea(.all)
-        .animation(.linear(duration: 0.2), value: animatableOpacity)
     }
+}
+
+/// A special view to handle hit-testing on background parts of popup content
+struct PopupHitTestingBackground: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = false
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {}
 }

--- a/Sources/PopupView/WindowManager.swift
+++ b/Sources/PopupView/WindowManager.swift
@@ -15,18 +15,30 @@ public final class WindowManager {
     private var windows: [UUID: UIWindow] = [:]
 
     // Show a new window with hosted SwiftUI content
-    public static func showInNewWindow<Content: View>(id: UUID, allowTapThroughBG: Bool, dismissClosure: @escaping ()->(), content: @escaping () -> Content) {
+    public static func showInNewWindow<Content: View>(
+        id: UUID,
+        closeOnTapOutside: Bool,
+        allowTapThroughBG: Bool,
+        dismissClosure: SendableClosure?,
+        content: @escaping () -> Content
+    ) {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
             print("No valid scene available")
             return
         }
 
-        let window = allowTapThroughBG ? UIPassthroughWindow(windowScene: scene) : UIWindow(windowScene: scene)
+        let window = UIPassthroughWindow(
+            windowScene: scene,
+            closeOnTapOutside: closeOnTapOutside,
+            isPassthrough: allowTapThroughBG,
+            dismissClosure: dismissClosure
+        )
+        
         window.backgroundColor = .clear
 
         let root = content()
             .environment(\.popupDismiss) {
-                dismissClosure()
+                dismissClosure?()
             }
         let controller: UIViewController
         if #available(iOS 18, *) {
@@ -50,40 +62,55 @@ public final class WindowManager {
 }
 
 class UIPassthroughWindow: UIWindow {
-
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if let vc = self.rootViewController {
-            vc.view.layoutSubviews() // otherwise the frame is as if the popup is still outside the screen
-            
-            let pointInRoot = vc.view.convert(point, from: self)
-            
-            // iOS26 Passthrough Find Issue
-            if #available(iOS 26, *), vc.view.point(inside: pointInRoot, with: event) {
-                return isTouchInsideSubviewForiOS26(point: pointInRoot, view: vc.view)
-            }
-            if let _ = isTouchInsideSubview(point: pointInRoot, view: vc.view) {
-                // pass tap to this UIPassthroughVC
-                return vc.view
-            }
-        }
-        return nil // pass to next window
+    var closeOnTapOutside: Bool
+    var isPassthrough: Bool
+    var dismissClosure: SendableClosure?
+    
+    init(windowScene: UIWindowScene, closeOnTapOutside: Bool, isPassthrough: Bool, dismissClosure: SendableClosure?) {
+        self.closeOnTapOutside = closeOnTapOutside
+        self.isPassthrough = isPassthrough
+        self.dismissClosure = dismissClosure
+        super.init(windowScene: windowScene)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    private func isTouchInsideSubview(point: CGPoint, view: UIView) -> UIView? {
-        for subview in view.subviews {
-            if subview.isUserInteractionEnabled, subview.frame.contains(point) {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let vc = self.rootViewController else {
+            return nil // pass to next window
+        }
+
+        vc.view.layoutIfNeeded() // otherwise the frame is as if the popup is still outside the screen
+
+        let layerHitTestResult = vc.view.layer.hitTest(vc.view.convert(point, from: self))
+        let superlayerDelegateName = layerHitTestResult?.superlayer?.delegate.map { String(describing: type(of: $0)) }
+        let didTapBackground = superlayerDelegateName?.contains(String(describing: PopupHitTestingBackground.self)) ?? false
+
+        if didTapBackground {
+            if closeOnTapOutside {
+                dismissClosure?()
+            }
+            
+            if isPassthrough {
+                return nil // pass to next window
+            }
+            return vc.view
+        }
+        
+        // pass tap to this
+        let farthestDescendent = super.hitTest(point, with: event)
+        return farthestDescendent
+    }
+
+    private func isTouchInsideSubview(point: CGPoint, vc: UIView) -> UIView? {
+        for subview in vc.subviews {
+            if subview.frame.contains(point) {
                 return subview
             }
         }
         return nil
-    }
-    
-    @available(iOS 26.0, *)
-    private func isTouchInsideSubviewForiOS26(point: CGPoint, view: UIView) -> UIView? {
-        guard view.layer.hitTest(point)?.name == nil else {
-            return nil
-        }
-        return view
     }
 }
 


### PR DESCRIPTION
Fix missing touch handling in the popups view when using `.allowTapThroughBG(true)`
Supports iOS 26+ with backward compatibility. Uses a dedicated `PopupHitTestingBackground` view as a hit-test marker.

Before:

https://github.com/user-attachments/assets/97f17b65-8ae9-4c49-9ef1-8f1ca5469b2d

After:

https://github.com/user-attachments/assets/b468216b-20c1-4a77-aecc-d50198743e9d


It also enables this combination, which now passes the touch through while still dismissing the popup. Previously, the popup did not dismiss:
```
.closeOnTapOutside(true)
.allowTapThroughBG(true)
```

Also, for this combination, dismissal no longer requires a strict tap gesture (press and release). It now works for swipes, pinch, pan, two-finger gestures, etc:
```
.closeOnTapOutside(true)
.allowTapThroughBG(false)
```
