### PR TITLE
Fix scroll

### DIFF
--- a/Sources/PopupView/PopupScrollViewDelegate.swift
+++ b/Sources/PopupView/PopupScrollViewDelegate.swift
@@ -20,6 +20,8 @@ extension UIScrollView {
 @MainActor
 final class PopupScrollViewDelegate: ObservableObject {
 
+    var keyboardHeightHelper = KeyboardHeightHelper()
+
     var scrollView: UIScrollView?
 
     var gestureIsCreated = false
@@ -31,7 +33,7 @@ final class PopupScrollViewDelegate: ObservableObject {
     func handlePan(_ gesture: UIPanGestureRecognizer) {
         let translation = gesture.translation(in: scrollView)
         let contentOffset = scrollView?.contentOffset.y ?? 0
-        let maxContentOffset = scrollView?.maxContentOffsetHeight() ?? 0
+        let maxContentOffset = (scrollView?.maxContentOffsetHeight() ?? 0) + keyboardHeightHelper.keyboardHeight
 
         if contentOffset - translation.y > 0 {
             scrollView?.contentOffset.y = min(contentOffset - translation.y, maxContentOffset)

--- a/Sources/PopupView/PublicAPI.swift
+++ b/Sources/PopupView/PublicAPI.swift
@@ -23,7 +23,7 @@ extension Popup {
         case toast
         case floater(verticalPadding: CGFloat = 10, horizontalPadding: CGFloat = 10, useSafeAreaInset: Bool = true)
 #if os(iOS)
-        case scroll(headerView: AnyView)
+        case scroll(headerView: AnyView = AnyView(Color.clear.frame(height: 1)))
 #endif
 
         var defaultPosition: Position {


### PR DESCRIPTION
Updated the scroll type. 
Now, when a scroll popup contains a keyboard, keyboard height is now calculated correctly for scroll.
I also updated the scroll type. 
If you don't need a header, you don't need to pass an EmptyView. You can simply use `.type(scroll())`