### PR TITLE
Fix .scroll popup shifting off-screen when keyboard appears

### DIFF
--- a/PopupExample/PopupExample/ContentView.swift
+++ b/PopupExample/PopupExample/ContentView.swift
@@ -260,6 +260,22 @@ struct ContentView : View {
                     .backgroundColor(.black.opacity(0.4))
                     .useKeyboardSafeArea(true)
             }
+
+#if os(iOS)
+        // Issue #281 reproduction: .scroll type + useKeyboardSafeArea(true) + TextField
+        // Bug: entire popup shifts up by full keyboard height instead of shrinking scroll area
+            .popup(isPresented: $inputSheets.showingScroll) {
+                ScrollInputSheet(isShowing: $inputSheets.showingScroll)
+            } customize: {
+                $0
+                    .type(.scroll(headerView: AnyView(scrollViewHeader())))
+                    .position(.bottom)
+                    .closeOnTap(false)
+                    .closeOnTapOutside(true)
+                    .backgroundColor(.black.opacity(0.4))
+                    .useKeyboardSafeArea(true)
+            }
+#endif
     }
 
     func createPopupsList() -> PopupsList {

--- a/PopupExample/PopupExample/Examples/InputSheets.swift
+++ b/PopupExample/PopupExample/Examples/InputSheets.swift
@@ -7,6 +7,40 @@
 
 import SwiftUI
 
+// Reproduces issue #281: .scroll type popup with useKeyboardSafeArea(true) shifts
+// the entire popup off-screen when the keyboard appears, instead of constraining
+// only the ScrollView height.
+struct ScrollInputSheet: View {
+    @Binding var isShowing: Bool
+
+    @State var comment: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Scrollable content area
+            ForEach(0..<8, id: \.self) { i in
+                Text("Item \(i + 1)")
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                Divider().padding(.horizontal, 20)
+            }
+
+            // TextField at the bottom of the scroll content
+            TextField("Leave a comment...", text: $comment)
+                .padding()
+                .frame(height: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.4), lineWidth: 1)
+                )
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 20)
+        }
+        .background(Color.white)
+    }
+}
+
 struct InputSheetBottom: View {
     @Binding var isShowing: Bool
 

--- a/PopupExample/PopupExample/PopupsList.swift
+++ b/PopupExample/PopupExample/PopupsList.swift
@@ -48,6 +48,7 @@ struct ActionSheetsState {
 
 struct InputSheetsState {
     var showingFirst = false
+    var showingScroll = false
 }
 
 private struct SectionHeader: View {
@@ -374,6 +375,16 @@ struct PopupsList: View {
                 InputSheetImage()
             }
         }
+#if os(iOS)
+        PopupButton(isShowing: $inputSheets.showingScroll, hideAll: hideAll) {
+            PopupTypeView(
+                title: "Scroll + Keyboard (issue #281)",
+                detail: "Scroll popup with TextField - popup should stay at bottom"
+            ) {
+                InputSheetImage()
+            }
+        }
+#endif
     }
 }
 

--- a/Sources/PopupView/PopupView.swift
+++ b/Sources/PopupView/PopupView.swift
@@ -167,8 +167,20 @@ public struct Popup<PopupContent: View>: ViewModifier {
                 return (screenHeight - sheetContentRect.height)/2 - safeAreaInsets.top
             }
             if position.isBottom {
+                // For .scroll type, keyboard avoidance is handled by constraining the
+                // ScrollView's maxHeight in contentView(), so we don't shift the popup frame.
+#if os(iOS)
+                let keyboardOffset: CGFloat
+                if case .scroll = type {
+                    keyboardOffset = 0
+                } else {
+                    keyboardOffset = useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0
+                }
+#else
+                let keyboardOffset: CGFloat = useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0
+#endif
                 return screenHeight - sheetContentRect.height
-                - (useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0)
+                - keyboardOffset
                 - verticalPadding
                 - (useSafeAreaInset ? safeAreaInsets.bottom : 0)
                 - safeAreaInsets.top
@@ -182,9 +194,21 @@ public struct Popup<PopupContent: View>: ViewModifier {
             return (presenterContentRect.height - sheetContentRect.height)/2
         }
         if position.isBottom {
+            // For .scroll type, keyboard avoidance is handled by constraining the
+            // ScrollView's maxHeight in contentView(), so we don't shift the popup frame.
+#if os(iOS)
+            let keyboardOffset: CGFloat
+            if case .scroll = type {
+                keyboardOffset = 0
+            } else {
+                keyboardOffset = useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0
+            }
+#else
+            let keyboardOffset: CGFloat = useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0
+#endif
             return presenterContentRect.height
             - sheetContentRect.height
-            - (useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0)
+            - keyboardOffset
             - verticalPadding
             + safeAreaInsets.bottom
             - (useSafeAreaInset ? safeAreaInsets.bottom : 0)
@@ -389,8 +413,10 @@ public struct Popup<PopupContent: View>: ViewModifier {
                 ScrollView {
                     view()
                 }
-                // no heigher than its contents
-                .frame(maxHeight: scrollViewContentHeight)
+                // Constrain to content height, and also subtract keyboard height when
+                // useKeyboardSafeArea is true so the scroll area shrinks instead of
+                // the whole popup frame being shifted upward (issue #281).
+                .frame(maxHeight: max(0, scrollViewContentHeight - (useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0)))
                 .frameGetter($scrollViewRect)
             }
             .introspect(.scrollView, on: .iOS(.v15...)) { scrollView in


### PR DESCRIPTION
## Summary

Fixes #281 — when a `.scroll` type popup uses `useKeyboardSafeArea(true)` and contains a `TextField`, tapping the field causes the entire popup to shift upward by the full keyboard height, pushing it mostly off-screen.

## Root cause

`displayedOffsetY` subtracted `keyboardHeight` from the popup's Y position for all bottom popups, including `.scroll` type. For scroll popups, `sheetContentRect.height` reflects the full scrollable content height, so the frame offset overshoots by ~300pt.

## Fix

- **`displayedOffsetY`**: For `.scroll` type, skip the keyboard Y offset entirely (set it to `0`). The popup frame stays anchored at the bottom of the screen.
- **`contentView()`**: For `.scroll` type, subtract `keyboardHeight` from the `ScrollView`'s `maxHeight` constraint instead, so the scroll area shrinks upward to make room for the keyboard while the header remains visible.

```swift
// Before (both overlay and non-overlay paths):
- (useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0)

// After: skip for .scroll type in displayedOffsetY, apply to ScrollView maxHeight instead
.frame(maxHeight: max(0, scrollViewContentHeight - (useKeyboardSafeArea ? keyboardHeightHelper.keyboardHeight : 0)))
```

## Test plan

- Added **"Scroll + Keyboard (issue #281)"** entry to the example app under the **Inputs** section
- Open the popup, tap the "Leave a comment..." TextField
- **Before fix**: popup flies up ~300pt off-screen
- **After fix**: popup stays at bottom, scroll area shrinks above the keyboard, TextField remains accessible